### PR TITLE
修复华为mate20pro emui10.1 系统语言为英文时不能自动解锁的问题

### DIFF
--- a/Modules/MODULE_UNLOCK.js
+++ b/Modules/MODULE_UNLOCK.js
@@ -2635,7 +2635,7 @@
                             "numeric_inputview"
                         );
                         let _emui = descMatches("" +
-                            "[Pp][Ii][Nn] ?码区域"
+                            "[Pp][Ii][Nn] ?.*" //支持系统语言为英文的emui 10.1
                         );
                         let _meizu = idMatches(_as +
                             "lockPattern"


### PR DESCRIPTION
修复华为mate20pro emui10.1 系统语言为英文时不能自动解锁的问题，修改的正则表达式有点简单粗暴，在我的手机上测试通过